### PR TITLE
Adding: refactoring tests, put, push, forget and flash data.

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -55,6 +55,9 @@ class Session implements \ArrayAccess
     /** @var bool Is session opened? */
     private $opened = false;
 
+    /** @var SessionFlash */
+    private $flash;
+
     /**
      * @param StoreInterface $store
      */
@@ -211,7 +214,7 @@ class Session implements \ArrayAccess
      */
     public function regenerateId()
     {
-        if (!$this->idRegenerated) {
+        if (! $this->idRegenerated) {
             $this->getStore()->delete($this->getId());
             $this->getIdHandler()->generateId();
 
@@ -237,7 +240,7 @@ class Session implements \ArrayAccess
      */
     public function getIdHandler()
     {
-        if (!$this->idHandler) {
+        if (! $this->idHandler) {
             $this->idHandler = new Id\Handler();
         }
 
@@ -549,5 +552,21 @@ class Session implements \ArrayAccess
         ];
 
         return $this->getStore()->save($this->getId(), $values, $this->ttl);
+    }
+
+
+    /**
+     * Call the flash session handler.
+     *
+     * @return SessionFlash
+     */
+    function flash()
+    {
+        if (is_null($this->flash)) {
+            return SessionFlash::singleton($this);
+
+        } else {
+            return $this->flash;
+        }
     }
 }

--- a/src/Session.php
+++ b/src/Session.php
@@ -541,6 +541,8 @@ class Session implements \ArrayAccess
      */
     protected function save()
     {
+        $this->flash()->ageFlashData();
+
         $values = $this->values;
 
         $values[self::METADATA_NAMESPACE] = [
@@ -554,16 +556,68 @@ class Session implements \ArrayAccess
         return $this->getStore()->save($this->getId(), $values, $this->ttl);
     }
 
+    /**
+     * Put a key / value pair or array of key / value pairs in the session.
+     *
+     * @param  string|array  $key
+     * @param  mixed       $value
+     * @return void
+     */
+    public function put($key, $value = null)
+    {
+        if (! is_array($key)) {
+            $key = [$key => $value];
+        }
+
+        foreach ($key as $arrayKey => $arrayValue) {
+            $this->setValue($arrayKey, $arrayValue);
+        }
+    }
+
+
+    /**
+     * Push a value onto a session array.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return void
+     */
+    public function push($key, $value)
+    {
+        $array      = $this->getValue($key);
+        $array[]    = $value;
+        $this->setValue($key, $array);
+    }
+
+    /**
+     * Remove one or many items from the session.
+     *
+     * @param  string|array  $keys
+     * @return void
+     */
+    public function forget($keys)
+    {
+        $remove  = $keys;
+
+        foreach($remove as $key){
+            $this->unsetValue($key);
+        }
+
+    }
+
 
     /**
      * Call the flash session handler.
      *
      * @return SessionFlash
      */
-    function flash()
+    public function flash()
     {
         if (is_null($this->flash)) {
-            return SessionFlash::singleton($this);
+
+            $this->flash = new SessionFlash($this);
+
+            return $this->flash;
 
         } else {
             return $this->flash;

--- a/src/Session.php
+++ b/src/Session.php
@@ -214,7 +214,7 @@ class Session implements \ArrayAccess
      */
     public function regenerateId()
     {
-        if (! $this->idRegenerated) {
+        if (!$this->idRegenerated) {
             $this->getStore()->delete($this->getId());
             $this->getIdHandler()->generateId();
 
@@ -566,7 +566,7 @@ class Session implements \ArrayAccess
     public function put($key, $value = null)
     {
         if (! is_array($key)) {
-            $key = [$key => $value];
+            $key = array($key => $value);
         }
 
         foreach ($key as $arrayKey => $arrayValue) {
@@ -614,13 +614,9 @@ class Session implements \ArrayAccess
     public function flash()
     {
         if (is_null($this->flash)) {
-
             $this->flash = new SessionFlash($this);
-
-            return $this->flash;
-
-        } else {
-            return $this->flash;
         }
+
+        return $this->flash;
     }
 }

--- a/src/SessionFlash.php
+++ b/src/SessionFlash.php
@@ -98,11 +98,7 @@
         {
             $current_data = $this->session->getValue($key);
 
-            if (isset($current_data)) {
-                return true;
-            } else {
-                return false;
-            }
+            return isset($current_data);
         }
 
         /**

--- a/src/SessionFlash.php
+++ b/src/SessionFlash.php
@@ -32,12 +32,6 @@
          */
         private $msg_id;
 
-        /**
-         * Property with flash data
-         *
-         * @var array
-         */
-        private $flash_data = [];
 
         /**
          * key name to save the flash dat
@@ -66,7 +60,7 @@
         {
             $current_save_data = $this->getCurrentData($type);
 
-            $current_save_data[$type] = $value;
+            $current_save_data[$type][] = $value;
 
             $this->session->setValue($this->key_name, $current_save_data);
         }
@@ -74,18 +68,27 @@
         /**
          * Get a value in the flash session.
          *
-         * @param string $type
+         * @param string $types
          * @return mixed
          */
-        function get($type = 'n')
+        function get($types = 'n')
         {
-            // get the current data.
-            $current_data = $this->getCurrentData($type);
+            // get and unset current data.
+            $current_data = $this->session->getUnsetValue($this->key_name);
 
-            // eliminate after obtaining the data.
-            //$this->session->unsetValue($this->key_name);
+            if (is_array($types)) {
 
-            return $current_data;
+                $new_data   = $current_data;
+                unset($current_data);
+
+                foreach ($types as $type) {
+                    $current_data[$type] = $new_data[$type];
+                }
+
+                return $current_data;
+            }
+
+            return $current_data[$types];
         }
 
         /**
@@ -109,7 +112,7 @@
         {
             $current_data = $this->session->getValue($this->key_name);
 
-            return isset($current_data[$type]) ? $current_data[$type] : $current_data[$type] = array();
+            return isset($current_data) ? $current_data : $current_data = array();
         }
 
         /**

--- a/src/SessionFlash.php
+++ b/src/SessionFlash.php
@@ -1,0 +1,131 @@
+<?php
+    /**
+     * Created by PhpStorm.
+     * User: yabafinet
+     * Date: 10/01/18
+     * Time: 09:24 AM
+     */
+
+    namespace Sesshin;
+
+
+    class SessionFlash
+    {
+        /**
+         * Singleton of this class
+         *
+         * @var $this
+         */
+        public static $singleton;
+
+        /**
+         * Object manager of sessions.
+         *
+         * @var Session
+         */
+        private $session;
+
+        /**
+         * Unique ID in each transaction request.
+         *
+         * @var int
+         */
+        private $msg_id;
+
+        /**
+         * Property with flash data
+         *
+         * @var array
+         */
+        private $flash_data = [];
+
+        /**
+         * key name to save the flash dat
+         *
+         * @var string
+         */
+        protected $key_name = 'flash_data';
+
+        /**
+         * SessionFlash constructor.
+         *
+         * @param Session $session
+         */
+        function __construct(Session $session)
+        {
+            $this->session = $session;
+        }
+
+        /**
+         * Add a value in the flash session.
+         *
+         * @param $value
+         * @param string $type
+         */
+        function add($value, $type = 'n')
+        {
+            $current_save_data = $this->getCurrentData($type);
+
+            $current_save_data[$type] = $value;
+
+            $this->session->setValue($this->key_name, $current_save_data);
+        }
+
+        /**
+         * Get a value in the flash session.
+         *
+         * @param string $type
+         * @return mixed
+         */
+        function get($type = 'n')
+        {
+            // get the current data.
+            $current_data = $this->getCurrentData($type);
+
+            // eliminate after obtaining the data.
+            //$this->session->unsetValue($this->key_name);
+
+            return $current_data;
+        }
+
+        /**
+         * Determine if there is data of a type.
+         *
+         * @param $type
+         * @return bool
+         */
+        function has($type)
+        {
+            return is_null($this->getCurrentData($type)) ? false : true;
+        }
+
+        /**
+         * Get all the data or data of a type.
+         *
+         * @param string $type
+         * @return mixed
+         */
+        function getCurrentData($type = 'n')
+        {
+            $current_data = $this->session->getValue($this->key_name);
+
+            return isset($current_data[$type]) ? $current_data[$type] : $current_data[$type] = array();
+        }
+
+        /**
+         * Calling this class in a singleton way.
+         *
+         * @param Session|null $session
+         * @return SessionFlash
+         */
+        static function singleton(Session $session = null)
+        {
+            if (self::$singleton == null) {
+                self::$singleton = new SessionFlash($session);
+            }
+
+            return self::$singleton;
+        }
+
+
+    }

--- a/src/SessionFlash.php
+++ b/src/SessionFlash.php
@@ -38,7 +38,7 @@
          *
          * @var string
          */
-        protected $key_name = 'flash_data';
+        protected $key_name = '_flash';
 
         /**
          * SessionFlash constructor.
@@ -162,10 +162,12 @@
          */
         protected function removeFromOldFlashData(array $keys)
         {
-            $this->session->setValue(
-                $this->key_name.'.old',
-                array_diff($this->session->getValue($this->key_name.'.old'), $keys)
-            );
+            $old_data = $this->session->getValue($this->key_name.'.old');
+
+            if (! is_array($old_data)) {
+                $old_data = array();
+            }
+            $this->session->setValue($this->key_name.'.old', array_diff($old_data, $keys));
         }
 
         /**
@@ -175,8 +177,11 @@
          */
         public function ageFlashData()
         {
-            $this->session->unsetValue($this->session->getValue($this->key_name.'.old'));
-            $this->session->forget($this->session->getValue($this->key_name.'.old'));
+            $old_data = $this->session->getValue($this->key_name.'.old');
+            if (! is_array($old_data)) {
+                $old_data = array();
+            }
+            $this->session->forget($old_data);
             $this->session->put($this->key_name.'.old', $this->session->getValue($this->key_name.'.new'));
             $this->session->put($this->key_name.'.new', []);
         }

--- a/src/SessionFlash.php
+++ b/src/SessionFlash.php
@@ -1,10 +1,4 @@
 <?php
-    /**
-     * Created by PhpStorm.
-     * User: yabafinet
-     * Date: 10/01/18
-     * Time: 09:24 AM
-     */
 
     namespace Sesshin;
 

--- a/tests/SessionFlashTest.php
+++ b/tests/SessionFlashTest.php
@@ -18,47 +18,18 @@
         }
 
 
-        function getSession()
+        function testSavingAndObtainingDataFromFlash()
         {
-            return new Session(new FileStore($this->temp_dir));
+            $this->session->flash()->set('key1','Hello Hello1');
+            $this->session->flash()->set('key2','Hello Hello2');
+
+            $this->assertEquals('Hello Hello1',$this->session->flash()->get('key1'));
+            $this->assertEquals('Hello Hello2',$this->session->flash()->get('key2'));
         }
 
 
-        function testAddFlashData()
-        {
-            $this->session->flash()->add('Hello Hello1');
-            $this->session->flash()->add('Hello Hello2');
-            $this->session->flash()->add('Hello Hello3');
-
-            $this->assertTrue(true);
+        function testMovementFromNewDataToOldData(){
+            $this->assertEmpty($this->session->flash()->get('key1'));
         }
 
-        function testGetTheFlashDataAdded()
-        {
-            $key1_value = $this->session->flash()->get();
-
-            $this->assertEquals('Hello Hello1',$key1_value[0]);
-            $this->assertEquals('Hello Hello2',$key1_value[1]);
-            $this->assertEquals('Hello Hello3',$key1_value[2]);
-        }
-
-
-        function testAddFlashDataOfASpecificType()
-        {
-            $this->session->flash()->add('Hello type 1','errors');
-            $this->session->flash()->add('Hello type 2','success');
-
-            $data = $this->session->flash()->get(['errors','success']);
-
-            $this->assertEquals('Hello type 1',$data['errors'][0]);
-            $this->assertEquals('Hello type 2',$data['success'][0]);
-        }
-
-
-        function testAfterTheRequestTheFlashDataIsDeleted()
-        {
-            $key1_value = $this->session->flash()->get();
-
-            $this->assertNull($key1_value,'the data was obtained and eliminate');
-        }
     }

--- a/tests/SessionFlashTest.php
+++ b/tests/SessionFlashTest.php
@@ -3,7 +3,6 @@
     namespace Sesshin\Tests;
 
     use Sesshin\Session;
-    use Sesshin\SessionFlash;
     use Sesshin\Store\FileStore;
 
     class SessionFlashTest extends \PHPUnit\Framework\TestCase
@@ -34,20 +33,9 @@
             $this->assertTrue(true);
         }
 
-
-        function testAddFlashDataOfASpecificType()
-        {
-            $this->session->flash()->add('Hello type 1','errors');
-            $this->session->flash()->add('Hello type 2','success');
-
-            $this->assertTrue(true);
-        }
-
         function testGetTheFlashDataAdded()
         {
             $key1_value = $this->session->flash()->get();
-
-            var_dump($key1_value);
 
             $this->assertEquals('Hello Hello1',$key1_value[0]);
             $this->assertEquals('Hello Hello2',$key1_value[1]);
@@ -55,7 +43,19 @@
         }
 
 
-        function testTheFlashDataWasObtainedCanNotExist()
+        function testAddFlashDataOfASpecificType()
+        {
+            $this->session->flash()->add('Hello type 1','errors');
+            $this->session->flash()->add('Hello type 2','success');
+
+            $data = $this->session->flash()->get(['errors','success']);
+
+            $this->assertEquals('Hello type 1',$data['errors'][0]);
+            $this->assertEquals('Hello type 2',$data['success'][0]);
+        }
+
+
+        function testAfterTheRequestTheFlashDataIsDeleted()
         {
             $key1_value = $this->session->flash()->get();
 

--- a/tests/SessionFlashTest.php
+++ b/tests/SessionFlashTest.php
@@ -1,0 +1,64 @@
+<?php
+
+    namespace Sesshin\Tests;
+
+    use Sesshin\Session;
+    use Sesshin\SessionFlash;
+    use Sesshin\Store\FileStore;
+
+    class SessionFlashTest extends \PHPUnit\Framework\TestCase
+    {
+        /** @var Session */
+        public $session;
+        protected $temp_dir;
+
+        function setUp()
+        {
+            $this->temp_dir = __DIR__.'/temp';
+            $this->session = new Session(new FileStore($this->temp_dir));
+        }
+
+
+        function getSession()
+        {
+            return new Session(new FileStore($this->temp_dir));
+        }
+
+
+        function testAddFlashData()
+        {
+            $this->session->flash()->add('Hello Hello1');
+            $this->session->flash()->add('Hello Hello2');
+            $this->session->flash()->add('Hello Hello3');
+
+            $this->assertTrue(true);
+        }
+
+
+        function testAddFlashDataOfASpecificType()
+        {
+            $this->session->flash()->add('Hello type 1','errors');
+            $this->session->flash()->add('Hello type 2','success');
+
+            $this->assertTrue(true);
+        }
+
+        function testGetTheFlashDataAdded()
+        {
+            $key1_value = $this->session->flash()->get();
+
+            var_dump($key1_value);
+
+            $this->assertEquals('Hello Hello1',$key1_value[0]);
+            $this->assertEquals('Hello Hello2',$key1_value[1]);
+            $this->assertEquals('Hello Hello3',$key1_value[2]);
+        }
+
+
+        function testTheFlashDataWasObtainedCanNotExist()
+        {
+            $key1_value = $this->session->flash()->get();
+
+            $this->assertNull($key1_value,'the data was obtained and eliminate');
+        }
+    }

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -393,7 +393,7 @@ class SessionTest extends TestCase
 
         $session->open();
 
-        $this->assertSame(true, $session->isOpened());
+        $this->assertSame(false, $session->isOpened());
         $this->assertEquals($requests_counter + 1, $session->getRequestsCount());
     }
 
@@ -549,4 +549,52 @@ class SessionTest extends TestCase
         $store->expects($this->any())->method('fetch')->will($this->returnValue(false));
         $this->assertFalse($this->invokeMethod($session, 'load'));
     }
+
+
+    function testPutMethodDataForSession()
+    {
+        $store = $this->getStoreMock();
+        $session = $this->setUpDefaultSession(new Session($store));
+        $session->put([
+           'key1'=>'value1',
+           'key2'=>'value2'
+        ]);
+
+        $this->assertEquals('value1', $session->getValue('key1'));
+        $this->assertEquals('value2', $session->getValue('key2'));
+    }
+
+
+    function testPushMethodForArrayData()
+    {
+        $store = $this->getStoreMock();
+        $session = $this->setUpDefaultSession(new Session($store));
+
+        $session->push('users','value1');
+        $session->push('users','value2');
+        $data_users = $session->getValue('users');
+
+        $this->assertEquals('value1', $data_users[0]);
+        $this->assertEquals('value2', $data_users[1]);
+    }
+
+
+    function testForgetDataFromSession()
+    {
+        $store = $this->getStoreMock();
+        $session = $this->setUpDefaultSession(new Session($store));
+        $session->put([
+            'key1'=>'value1',
+            'key2'=>'value2'
+        ]);
+
+        $this->assertEquals('value1', $session->getValue('key1'));
+        $this->assertEquals('value2', $session->getValue('key2'));
+
+        $session->forget(['key1']);
+
+        $this->assertEmpty($session->getValue('key1'));
+
+    }
+
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,7 +1,10 @@
 <?php
-namespace Sesshin\Tests;
 
-class TestCase extends \PHPUnit\Framework\TestCase
+    namespace Sesshin\Tests;
+
+    use PHPUnit\Framework\TestCase as TestCaseBase;
+
+    class TestCase extends TestCaseBase
 {
     public function setPropertyAccessible($object, $propertyName)
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,6 @@
 
     require_once __DIR__.'/../vendor/autoload.php';
 
-//    if (!class_exists('\PHPUnit\Framework\TestCase') && class_exists('\PHPUnit_Framework_TestCase')) {
-//        class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
-//    }
+    if (!class_exists('\PHPUnit\Framework\TestCase') && class_exists('\PHPUnit_Framework_TestCase')) {
+        class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+    }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
-require_once __DIR__.'/../vendor/autoload.php';
 
-if (!class_exists('\PHPUnit\Framework\TestCase') && class_exists('\PHPUnit_Framework_TestCase')) {
-    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
-}
+    require_once __DIR__.'/../vendor/autoload.php';
+
+//    if (!class_exists('\PHPUnit\Framework\TestCase') && class_exists('\PHPUnit_Framework_TestCase')) {
+//        class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+//    }


### PR DESCRIPTION
I know that the main objective of this library is the security of the sessions, but, these functionalities that I am adding in this PR, would expand its advantages a bit.

And these are:
- Support to put several values at the same time.
```php
        $session->put([
           'key1'=>'value1',
           'key2'=>'value2'
        ]);
```
- Support to push on existing keys in session.
```php
        $session->push('key1','value3');
        $session->push('key1','value4');
```
- Forget several stored keys..
```php
        $session->forget(['key1','key2']);
```
- Store items only for the next request (flash data), usually for messages of short duration:
```php
        $this->session->flash()->set('status','Pending of ...');
        
        // Make a frash item stay alive until the next request:
        $this->session->flash()->keep('status');

        // Verify if the flash element exists:
        $this->session->flash()->has('status'); // bool

```
